### PR TITLE
Fix timescaledb installation logic (#1079)

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -34,7 +34,6 @@ pipeline:
                           --build-arg PGVERSION="$PGVERSION" \
                           --build-arg BASE_IMAGE="$BASE_IMAGE" \
                           --build-arg PGOLDVERSIONS="14 15 16" \
-                          --build-arg TIMESCALEDB="2.17.2" \
                           -t "$ECR_TEST_IMAGE" \
                           --push .
 
@@ -64,7 +63,6 @@ pipeline:
                           --build-arg PGVERSION="$PGVERSION" \
                           --build-arg BASE_IMAGE="$BASE_IMAGE" \
                           --build-arg PGOLDVERSIONS="14 15 16" \
-                          --build-arg TIMESCALEDB="2.17.2" \
                           -t "$ECR_TEST_IMAGE" \
                           --push .
       cdp-promote-image "$ECR_TEST_IMAGE"
@@ -96,7 +94,6 @@ pipeline:
                           --build-arg PGVERSION="$PGVERSION" \
                           --build-arg BASE_IMAGE="$BASE_IMAGE" \
                           --build-arg PGOLDVERSIONS="14 15 16" \
-                          --build-arg TIMESCALEDB="2.17.2" \
                           -t "$ECR_TEST_IMAGE" \
                           --push .
       cdp-promote-image "$ECR_TEST_IMAGE"

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -1,6 +1,5 @@
 ARG BASE_IMAGE=ubuntu:22.04
 ARG PGVERSION=17
-ARG TIMESCALEDB="2.15.3 2.18.0"
 ARG DEMO=false
 ARG COMPRESS=false
 ARG ADDITIONAL_LOCALES=
@@ -44,7 +43,6 @@ COPY build_scripts/base.sh /builddeps/
 COPY --from=dependencies-builder /builddeps/*.deb /builddeps/
 
 ARG PGVERSION
-ARG TIMESCALEDB
 ARG TIMESCALEDB_APACHE_ONLY=true
 ARG TIMESCALEDB_TOOLKIT=true
 ARG COMPRESS

--- a/postgres-appliance/build_scripts/base.sh
+++ b/postgres-appliance/build_scripts/base.sh
@@ -121,18 +121,18 @@ for version in $DEB_PG_SUPPORTED_VERSIONS; do
         "postgresql-${version}-pg-stat-kcache" \
         "${EXTRAS[@]}"
 
-    # Clean up timescaledb versions except the highest compatible version
+    # Clean up timescaledb versions except the highest compatible and transition version
     exclude_patterns=()
-    exclude_patterns_tsl=()
-    for ts_version in ${TIMESCALEDB}; do
-        exclude_patterns+=(! -name timescaledb-"${ts_version}".so)
-        exclude_patterns_tsl+=(! -name timescaledb-tsl-"${ts_version}".so)
-    done
-    find /usr/lib/postgresql/"${version}"/lib/ -name 'timescaledb-2.*.so' "${exclude_patterns[@]}" -delete;
-
-    if [ "${TIMESCALEDB_APACHE_ONLY}" != "true" ]; then
-        find /usr/lib/postgresql/"${version}"/lib/ -name 'timescaledb-tsl-2.*.so' "${exclude_patterns_tsl[@]}" -delete;
+    prev_highest_ver="$ts_highest_ver"
+    ts_highest_ver=$(find "/usr/lib/postgresql/$version/lib/" -name 'timescaledb-2.*.so' | sed -rn 's/.*timescaledb-([1-9]+\.[0-9]+\.[0-9]+)\.so$/\1/p' | sort -rV | head -n1)
+    if [ "$prev_highest_ver" != "$ts_highest_ver" ]; then
+        ts_transition_version="$prev_highest_ver"
     fi
+    for ts_version in "$ts_transition_version" "$ts_highest_ver"; do
+        exclude_patterns+=(! -name timescaledb-"${ts_version}".so)
+        exclude_patterns+=(! -name timescaledb-tsl-"${ts_version}".so)
+    done
+    find "/usr/lib/postgresql/$version/lib/" \( -name 'timescaledb-2.*.so' -o -name 'timescaledb-tsl-2.*.so' \) "${exclude_patterns[@]}" -delete
 
     # Install 3rd party stuff
 


### PR DESCRIPTION
- properly delete *.so for different setups
- always keep the latest compatible and transition timescaledb ver without specifying in a build arg